### PR TITLE
Provide high level Assertions classes as entry points

### DIFF
--- a/generate-assertions-java.py
+++ b/generate-assertions-java.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+
+from datetime import date
+import os
+import re
+
+SRC_DIR = 'src/main/java/'
+ABSTRACT = re.compile(r'public abstract class Abstract')
+TYPE   = re.compile(r'class [A-Za-z0-9]+(<[^>]+?(?: extends ([A-Za-z0-9_]+))?>)?')
+TARGET = re.compile(r'\s[A-Z][A-Za-z0-9_]+<[A-Z][A-Za-z0-9_]+(?:<.+?>)?, (([A-Z][A-Za-z0-9_]+).*?)(<.+?>)?(?:, [A-Z])*> {')
+IMPORT = re.compile(r'import (?:static )?((?:com\.google\.)?android\..*?);')
+ASSERTIONS = 'Assertions.java'
+
+
+projects = []
+for candidate in filter(os.path.isdir, os.listdir('.')):
+  if candidate.startswith('truth-android'):
+    projects.append(candidate)
+print('Projects: %s\n' % projects)
+
+
+def _find_assertions(path):
+  for root, dirs, files in os.walk(path):
+    if ASSERTIONS in files:
+      return os.path.join(root, ASSERTIONS)
+  raise Exception('Could not locate Assertions.java in %s.' % path)
+
+
+for project in projects:
+  src_dir = os.path.join(project, SRC_DIR)
+  assertions_file = _find_assertions(src_dir)
+  assertions_dir = os.path.dirname(assertions_file)
+  classes_package = assertions_dir[len(src_dir):].replace(os.sep, '.')
+
+  print('\n' * 3)
+  print(project)
+  print('')
+  print('src_dir = %s' % src_dir)
+  print('assertions_file = %s' % assertions_file)
+  print('assertions_dir = %s' % assertions_dir)
+  print('classes_package = %s' % classes_package)
+  print('')
+
+  assertions = []
+  for root, dirs, files in os.walk(assertions_dir):
+    for f in files:
+      if not f.endswith('Subject.java'):
+        continue
+      print('-'*80)
+
+      local_package = root[len(src_dir):].replace(os.sep, '.')
+      package = '%s.%s' % (local_package, f[:-5])
+      print('package    : %s' % package)
+
+      with open(os.path.join(root, f)) as j:
+        java = j.read()
+      if ABSTRACT.search(java) is not None:
+        print('SKIP (abstract)')
+        continue # Abstract class.
+
+      target_match = TARGET.search(java)
+      import_type = target_match.group(2)
+      target_type = target_match.group(1)
+      generics    = target_match.group(3)
+      print('import type: %s' % import_type)
+      print('target type: %s' % target_type)
+      print('generics   : %s' % generics)
+
+      for match in IMPORT.finditer(java):
+        if match.group(1).endswith(import_type):
+          import_package = match.group(1)
+          break
+      else:
+        raise Exception('Could not find target package for %s' % import_type)
+
+      type_match = TYPE.search(java)
+      bounds_type = type_match.group(1)
+      bounds_ext  = type_match.group(2)
+      if generics:
+        print('bounds type: %s' % bounds_type)
+        print('bounds ext : %s' % bounds_ext)
+
+      if bounds_ext:
+        for match in IMPORT.finditer(java):
+          if match.group(1).endswith(bounds_ext):
+            bounds_type = bounds_type.replace(bounds_ext, match.group(1))
+            break
+        else:
+          raise Exception('Could not find target package for %s' % bounds_ext)
+        print('bounds fqcn: %s' % bounds_type)
+
+      target_package = import_package.replace(import_type, target_type)
+      print('import pkg : %s' % import_package)
+      print('target pkg : %s' % target_package)
+
+      assertions.append(
+        (package, target_package, bounds_type or '', generics or '')
+      )
+
+  print('-'*80)
+
+  with open(assertions_file, 'w') as out:
+    out.write('// Copyright %s PKWARE, Inc.\n' % date.today().year)
+    out.write('//\n')
+    out.write('// This class is generated. Do not modify directly!\n')
+    out.write('package %s;\n\n' % classes_package)
+    out.write('import com.google.common.truth.SubjectFactory;\n\n')
+    out.write('import static com.google.common.truth.Truth.assertAbout;\n\n')
+    out.write('/** Assertions for testing Android classes. */\n')
+    out.write('@SuppressWarnings("deprecation")\n')
+    out.write('public final class Assertions {')
+    for package, target_package, bounds_type, generic_keys in sorted(assertions, key=lambda x: x[0]):
+      out.write('\n')
+      out.write('  public static %s%s%s assertThat(\n' % (bounds_type + ' ' if bounds_type else '', package, generic_keys))
+      out.write('      %s%s target) {\n' % (target_package, generic_keys))
+      out.write('    SubjectFactory<%s%s, %s%s> type = %s.type();\n' % (package, generic_keys, target_package, generic_keys, package))
+      out.write('    return assertAbout(type).that(target);\n')
+      out.write('  }\n')
+    out.write('\n')
+    out.write('  private Assertions() {\n')
+    out.write('    throw new AssertionError("No instances.");\n')
+    out.write('  }\n')
+    out.write('}\n')
+
+
+print('\nNew Assertion./s.java files written!\n')

--- a/truth-android-appcompat-v7/src/main/java/com/pkware/truth/android/appcompat/v7/Assertions.java
+++ b/truth-android-appcompat-v7/src/main/java/com/pkware/truth/android/appcompat/v7/Assertions.java
@@ -1,0 +1,40 @@
+// Copyright 2016 PKWARE, Inc.
+//
+// This class is generated. Do not modify directly!
+package com.pkware.truth.android.appcompat.v7;
+
+import com.google.common.truth.SubjectFactory;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+/** Assertions for testing Android classes. */
+@SuppressWarnings("deprecation")
+public final class Assertions {
+  public static com.pkware.truth.android.appcompat.v7.app.ActionBarSubject assertThat(
+      android.support.v7.app.ActionBar target) {
+    SubjectFactory<com.pkware.truth.android.appcompat.v7.app.ActionBarSubject, android.support.v7.app.ActionBar> type = com.pkware.truth.android.appcompat.v7.app.ActionBarSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.appcompat.v7.view.ActionModeSubject assertThat(
+      android.support.v7.view.ActionMode target) {
+    SubjectFactory<com.pkware.truth.android.appcompat.v7.view.ActionModeSubject, android.support.v7.view.ActionMode> type = com.pkware.truth.android.appcompat.v7.view.ActionModeSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.appcompat.v7.widget.LinearLayoutCompatSubject assertThat(
+      android.support.v7.widget.LinearLayoutCompat target) {
+    SubjectFactory<com.pkware.truth.android.appcompat.v7.widget.LinearLayoutCompatSubject, android.support.v7.widget.LinearLayoutCompat> type = com.pkware.truth.android.appcompat.v7.widget.LinearLayoutCompatSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.appcompat.v7.widget.SearchViewSubject assertThat(
+      android.support.v7.widget.SearchView target) {
+    SubjectFactory<com.pkware.truth.android.appcompat.v7.widget.SearchViewSubject, android.support.v7.widget.SearchView> type = com.pkware.truth.android.appcompat.v7.widget.SearchViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  private Assertions() {
+    throw new AssertionError("No instances.");
+  }
+}

--- a/truth-android-cardview-v7/src/main/java/com/pkware/truth/android/cardview/v7/Assertions.java
+++ b/truth-android-cardview-v7/src/main/java/com/pkware/truth/android/cardview/v7/Assertions.java
@@ -1,0 +1,22 @@
+// Copyright 2016 PKWARE, Inc.
+//
+// This class is generated. Do not modify directly!
+package com.pkware.truth.android.cardview.v7;
+
+import com.google.common.truth.SubjectFactory;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+/** Assertions for testing Android classes. */
+@SuppressWarnings("deprecation")
+public final class Assertions {
+  public static com.pkware.truth.android.cardview.v7.widget.CardViewSubject assertThat(
+      android.support.v7.widget.CardView target) {
+    SubjectFactory<com.pkware.truth.android.cardview.v7.widget.CardViewSubject, android.support.v7.widget.CardView> type = com.pkware.truth.android.cardview.v7.widget.CardViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  private Assertions() {
+    throw new AssertionError("No instances.");
+  }
+}

--- a/truth-android-design/src/main/java/com/pkware/truth/android/design/Assertions.java
+++ b/truth-android-design/src/main/java/com/pkware/truth/android/design/Assertions.java
@@ -1,0 +1,46 @@
+// Copyright 2016 PKWARE, Inc.
+//
+// This class is generated. Do not modify directly!
+package com.pkware.truth.android.design;
+
+import com.google.common.truth.SubjectFactory;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+/** Assertions for testing Android classes. */
+@SuppressWarnings("deprecation")
+public final class Assertions {
+  public static com.pkware.truth.android.design.widget.NavigationViewSubject assertThat(
+      android.support.design.widget.NavigationView target) {
+    SubjectFactory<com.pkware.truth.android.design.widget.NavigationViewSubject, android.support.design.widget.NavigationView> type = com.pkware.truth.android.design.widget.NavigationViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.design.widget.SnackbarSubject assertThat(
+      android.support.design.widget.Snackbar target) {
+    SubjectFactory<com.pkware.truth.android.design.widget.SnackbarSubject, android.support.design.widget.Snackbar> type = com.pkware.truth.android.design.widget.SnackbarSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.design.widget.TabLayoutSubject assertThat(
+      android.support.design.widget.TabLayout target) {
+    SubjectFactory<com.pkware.truth.android.design.widget.TabLayoutSubject, android.support.design.widget.TabLayout> type = com.pkware.truth.android.design.widget.TabLayoutSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.design.widget.TabLayoutTabSubject assertThat(
+      android.support.design.widget.TabLayout.Tab target) {
+    SubjectFactory<com.pkware.truth.android.design.widget.TabLayoutTabSubject, android.support.design.widget.TabLayout.Tab> type = com.pkware.truth.android.design.widget.TabLayoutTabSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.design.widget.TextInputLayoutSubject assertThat(
+      android.support.design.widget.TextInputLayout target) {
+    SubjectFactory<com.pkware.truth.android.design.widget.TextInputLayoutSubject, android.support.design.widget.TextInputLayout> type = com.pkware.truth.android.design.widget.TextInputLayoutSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  private Assertions() {
+    throw new AssertionError("No instances.");
+  }
+}

--- a/truth-android-gridlayout-v7/src/main/java/com/pkware/truth/android/gridlayout/v7/Assertions.java
+++ b/truth-android-gridlayout-v7/src/main/java/com/pkware/truth/android/gridlayout/v7/Assertions.java
@@ -1,0 +1,22 @@
+// Copyright 2016 PKWARE, Inc.
+//
+// This class is generated. Do not modify directly!
+package com.pkware.truth.android.gridlayout.v7;
+
+import com.google.common.truth.SubjectFactory;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+/** Assertions for testing Android classes. */
+@SuppressWarnings("deprecation")
+public final class Assertions {
+  public static com.pkware.truth.android.gridlayout.v7.widget.GridLayoutSubject assertThat(
+      android.support.v7.widget.GridLayout target) {
+    SubjectFactory<com.pkware.truth.android.gridlayout.v7.widget.GridLayoutSubject, android.support.v7.widget.GridLayout> type = com.pkware.truth.android.gridlayout.v7.widget.GridLayoutSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  private Assertions() {
+    throw new AssertionError("No instances.");
+  }
+}

--- a/truth-android-mediarouter-v7/src/main/java/com/pkware/truth/android/mediarouter/v7/Assertions.java
+++ b/truth-android-mediarouter-v7/src/main/java/com/pkware/truth/android/mediarouter/v7/Assertions.java
@@ -1,0 +1,64 @@
+// Copyright 2016 PKWARE, Inc.
+//
+// This class is generated. Do not modify directly!
+package com.pkware.truth.android.mediarouter.v7;
+
+import com.google.common.truth.SubjectFactory;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+/** Assertions for testing Android classes. */
+@SuppressWarnings("deprecation")
+public final class Assertions {
+  public static com.pkware.truth.android.mediarouter.v7.media.MediaItemStatusSubject assertThat(
+      android.support.v7.media.MediaItemStatus target) {
+    SubjectFactory<com.pkware.truth.android.mediarouter.v7.media.MediaItemStatusSubject, android.support.v7.media.MediaItemStatus> type = com.pkware.truth.android.mediarouter.v7.media.MediaItemStatusSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.mediarouter.v7.media.MediaRouteDescriptorSubject assertThat(
+      android.support.v7.media.MediaRouteDescriptor target) {
+    SubjectFactory<com.pkware.truth.android.mediarouter.v7.media.MediaRouteDescriptorSubject, android.support.v7.media.MediaRouteDescriptor> type = com.pkware.truth.android.mediarouter.v7.media.MediaRouteDescriptorSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.mediarouter.v7.media.MediaRouteDiscoveryRequestSubject assertThat(
+      android.support.v7.media.MediaRouteDiscoveryRequest target) {
+    SubjectFactory<com.pkware.truth.android.mediarouter.v7.media.MediaRouteDiscoveryRequestSubject, android.support.v7.media.MediaRouteDiscoveryRequest> type = com.pkware.truth.android.mediarouter.v7.media.MediaRouteDiscoveryRequestSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.mediarouter.v7.media.MediaRouteProviderProviderMetadataSubject assertThat(
+      android.support.v7.media.MediaRouteProvider.ProviderMetadata target) {
+    SubjectFactory<com.pkware.truth.android.mediarouter.v7.media.MediaRouteProviderProviderMetadataSubject, android.support.v7.media.MediaRouteProvider.ProviderMetadata> type = com.pkware.truth.android.mediarouter.v7.media.MediaRouteProviderProviderMetadataSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.mediarouter.v7.media.MediaRouterProviderInfoSubject assertThat(
+      android.support.v7.media.MediaRouter.ProviderInfo target) {
+    SubjectFactory<com.pkware.truth.android.mediarouter.v7.media.MediaRouterProviderInfoSubject, android.support.v7.media.MediaRouter.ProviderInfo> type = com.pkware.truth.android.mediarouter.v7.media.MediaRouterProviderInfoSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.mediarouter.v7.media.MediaRouterRouteInfoSubject assertThat(
+      android.support.v7.media.MediaRouter.RouteInfo target) {
+    SubjectFactory<com.pkware.truth.android.mediarouter.v7.media.MediaRouterRouteInfoSubject, android.support.v7.media.MediaRouter.RouteInfo> type = com.pkware.truth.android.mediarouter.v7.media.MediaRouterRouteInfoSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.mediarouter.v7.media.MediaSessionStatusSubject assertThat(
+      android.support.v7.media.MediaSessionStatus target) {
+    SubjectFactory<com.pkware.truth.android.mediarouter.v7.media.MediaSessionStatusSubject, android.support.v7.media.MediaSessionStatus> type = com.pkware.truth.android.mediarouter.v7.media.MediaSessionStatusSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.mediarouter.v7.media.RemotePlaybackClientSubject assertThat(
+      android.support.v7.media.RemotePlaybackClient target) {
+    SubjectFactory<com.pkware.truth.android.mediarouter.v7.media.RemotePlaybackClientSubject, android.support.v7.media.RemotePlaybackClient> type = com.pkware.truth.android.mediarouter.v7.media.RemotePlaybackClientSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  private Assertions() {
+    throw new AssertionError("No instances.");
+  }
+}

--- a/truth-android-palette-v7/src/main/java/com/pkware/truth/android/palette/v7/Assertions.java
+++ b/truth-android-palette-v7/src/main/java/com/pkware/truth/android/palette/v7/Assertions.java
@@ -1,0 +1,28 @@
+// Copyright 2016 PKWARE, Inc.
+//
+// This class is generated. Do not modify directly!
+package com.pkware.truth.android.palette.v7;
+
+import com.google.common.truth.SubjectFactory;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+/** Assertions for testing Android classes. */
+@SuppressWarnings("deprecation")
+public final class Assertions {
+  public static com.pkware.truth.android.palette.v7.graphics.PaletteSubject assertThat(
+      android.support.v7.graphics.Palette target) {
+    SubjectFactory<com.pkware.truth.android.palette.v7.graphics.PaletteSubject, android.support.v7.graphics.Palette> type = com.pkware.truth.android.palette.v7.graphics.PaletteSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.palette.v7.graphics.PaletteSwatchSubject assertThat(
+      android.support.v7.graphics.Palette.Swatch target) {
+    SubjectFactory<com.pkware.truth.android.palette.v7.graphics.PaletteSwatchSubject, android.support.v7.graphics.Palette.Swatch> type = com.pkware.truth.android.palette.v7.graphics.PaletteSwatchSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  private Assertions() {
+    throw new AssertionError("No instances.");
+  }
+}

--- a/truth-android-play-services/src/main/java/com/pkware/truth/android/playservices/Assertions.java
+++ b/truth-android-play-services/src/main/java/com/pkware/truth/android/playservices/Assertions.java
@@ -1,0 +1,58 @@
+// Copyright 2016 PKWARE, Inc.
+//
+// This class is generated. Do not modify directly!
+package com.pkware.truth.android.playservices;
+
+import com.google.common.truth.SubjectFactory;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+/** Assertions for testing Android classes. */
+@SuppressWarnings("deprecation")
+public final class Assertions {
+  public static com.pkware.truth.android.playservices.location.ActivityRecognitionResultSubject assertThat(
+      com.google.android.gms.location.ActivityRecognitionResult target) {
+    SubjectFactory<com.pkware.truth.android.playservices.location.ActivityRecognitionResultSubject, com.google.android.gms.location.ActivityRecognitionResult> type = com.pkware.truth.android.playservices.location.ActivityRecognitionResultSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.playservices.location.DetectedActivitySubject assertThat(
+      com.google.android.gms.location.DetectedActivity target) {
+    SubjectFactory<com.pkware.truth.android.playservices.location.DetectedActivitySubject, com.google.android.gms.location.DetectedActivity> type = com.pkware.truth.android.playservices.location.DetectedActivitySubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.playservices.location.LocationRequestSubject assertThat(
+      com.google.android.gms.location.LocationRequest target) {
+    SubjectFactory<com.pkware.truth.android.playservices.location.LocationRequestSubject, com.google.android.gms.location.LocationRequest> type = com.pkware.truth.android.playservices.location.LocationRequestSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.playservices.maps.CameraPositionSubject assertThat(
+      com.google.android.gms.maps.model.CameraPosition target) {
+    SubjectFactory<com.pkware.truth.android.playservices.maps.CameraPositionSubject, com.google.android.gms.maps.model.CameraPosition> type = com.pkware.truth.android.playservices.maps.CameraPositionSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.playservices.maps.GoogleMapSubject assertThat(
+      com.google.android.gms.maps.GoogleMap target) {
+    SubjectFactory<com.pkware.truth.android.playservices.maps.GoogleMapSubject, com.google.android.gms.maps.GoogleMap> type = com.pkware.truth.android.playservices.maps.GoogleMapSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.playservices.maps.MarkerSubject assertThat(
+      com.google.android.gms.maps.model.Marker target) {
+    SubjectFactory<com.pkware.truth.android.playservices.maps.MarkerSubject, com.google.android.gms.maps.model.Marker> type = com.pkware.truth.android.playservices.maps.MarkerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.playservices.maps.UiSettingsSubject assertThat(
+      com.google.android.gms.maps.UiSettings target) {
+    SubjectFactory<com.pkware.truth.android.playservices.maps.UiSettingsSubject, com.google.android.gms.maps.UiSettings> type = com.pkware.truth.android.playservices.maps.UiSettingsSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  private Assertions() {
+    throw new AssertionError("No instances.");
+  }
+}

--- a/truth-android-recyclerview-v7/src/main/java/com/pkware/truth/android/recyclerview/v7/Assertions.java
+++ b/truth-android-recyclerview-v7/src/main/java/com/pkware/truth/android/recyclerview/v7/Assertions.java
@@ -1,0 +1,64 @@
+// Copyright 2016 PKWARE, Inc.
+//
+// This class is generated. Do not modify directly!
+package com.pkware.truth.android.recyclerview.v7;
+
+import com.google.common.truth.SubjectFactory;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+/** Assertions for testing Android classes. */
+@SuppressWarnings("deprecation")
+public final class Assertions {
+  public static <VH extends android.support.v7.widget.RecyclerView.ViewHolder> com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewAdapterSubject<VH> assertThat(
+      android.support.v7.widget.RecyclerView.Adapter<VH> target) {
+    SubjectFactory<com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewAdapterSubject<VH>, android.support.v7.widget.RecyclerView.Adapter<VH>> type = com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewAdapterSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewItemAnimatorSubject assertThat(
+      android.support.v7.widget.RecyclerView.ItemAnimator target) {
+    SubjectFactory<com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewItemAnimatorSubject, android.support.v7.widget.RecyclerView.ItemAnimator> type = com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewItemAnimatorSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewLayoutManagerSubject assertThat(
+      android.support.v7.widget.RecyclerView.LayoutManager target) {
+    SubjectFactory<com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewLayoutManagerSubject, android.support.v7.widget.RecyclerView.LayoutManager> type = com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewLayoutManagerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewLayoutParamsSubject assertThat(
+      android.support.v7.widget.RecyclerView.LayoutParams target) {
+    SubjectFactory<com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewLayoutParamsSubject, android.support.v7.widget.RecyclerView.LayoutParams> type = com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewLayoutParamsSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewSmoothScrollerActionSubject assertThat(
+      android.support.v7.widget.RecyclerView.SmoothScroller.Action target) {
+    SubjectFactory<com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewSmoothScrollerActionSubject, android.support.v7.widget.RecyclerView.SmoothScroller.Action> type = com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewSmoothScrollerActionSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewSmoothScrollerSubject assertThat(
+      android.support.v7.widget.RecyclerView.SmoothScroller target) {
+    SubjectFactory<com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewSmoothScrollerSubject, android.support.v7.widget.RecyclerView.SmoothScroller> type = com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewSmoothScrollerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewSubject assertThat(
+      android.support.v7.widget.RecyclerView target) {
+    SubjectFactory<com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewSubject, android.support.v7.widget.RecyclerView> type = com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewViewHolderSubject assertThat(
+      android.support.v7.widget.RecyclerView.ViewHolder target) {
+    SubjectFactory<com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewViewHolderSubject, android.support.v7.widget.RecyclerView.ViewHolder> type = com.pkware.truth.android.recyclerview.v7.widget.RecyclerViewViewHolderSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  private Assertions() {
+    throw new AssertionError("No instances.");
+  }
+}

--- a/truth-android-support-v4/src/main/java/com/pkware/truth/android/support/v4/Assertions.java
+++ b/truth-android-support-v4/src/main/java/com/pkware/truth/android/support/v4/Assertions.java
@@ -1,0 +1,154 @@
+// Copyright 2016 PKWARE, Inc.
+//
+// This class is generated. Do not modify directly!
+package com.pkware.truth.android.support.v4;
+
+import com.google.common.truth.SubjectFactory;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+/** Assertions for testing Android classes. */
+@SuppressWarnings("deprecation")
+public final class Assertions {
+  public static com.pkware.truth.android.support.v4.app.ActionBarDrawerToggleSubject assertThat(
+      android.support.v4.app.ActionBarDrawerToggle target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.app.ActionBarDrawerToggleSubject, android.support.v4.app.ActionBarDrawerToggle> type = com.pkware.truth.android.support.v4.app.ActionBarDrawerToggleSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.app.DialogFragmentSubject assertThat(
+      android.support.v4.app.DialogFragment target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.app.DialogFragmentSubject, android.support.v4.app.DialogFragment> type = com.pkware.truth.android.support.v4.app.DialogFragmentSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.app.FragmentManagerSubject assertThat(
+      android.support.v4.app.FragmentManager target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.app.FragmentManagerSubject, android.support.v4.app.FragmentManager> type = com.pkware.truth.android.support.v4.app.FragmentManagerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.app.FragmentSubject assertThat(
+      android.support.v4.app.Fragment target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.app.FragmentSubject, android.support.v4.app.Fragment> type = com.pkware.truth.android.support.v4.app.FragmentSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.app.FragmentTransactionSubject assertThat(
+      android.support.v4.app.FragmentTransaction target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.app.FragmentTransactionSubject, android.support.v4.app.FragmentTransaction> type = com.pkware.truth.android.support.v4.app.FragmentTransactionSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.app.ListFragmentSubject assertThat(
+      android.support.v4.app.ListFragment target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.app.ListFragmentSubject, android.support.v4.app.ListFragment> type = com.pkware.truth.android.support.v4.app.ListFragmentSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.app.LoaderManagerSubject assertThat(
+      android.support.v4.app.LoaderManager target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.app.LoaderManagerSubject, android.support.v4.app.LoaderManager> type = com.pkware.truth.android.support.v4.app.LoaderManagerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.content.CursorLoaderSubject assertThat(
+      android.support.v4.content.CursorLoader target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.content.CursorLoaderSubject, android.support.v4.content.CursorLoader> type = com.pkware.truth.android.support.v4.content.CursorLoaderSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.content.LoaderSubject assertThat(
+      android.support.v4.content.Loader target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.content.LoaderSubject, android.support.v4.content.Loader> type = com.pkware.truth.android.support.v4.content.LoaderSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.media.TransportControllerSubject assertThat(
+      android.support.v4.media.TransportController target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.media.TransportControllerSubject, android.support.v4.media.TransportController> type = com.pkware.truth.android.support.v4.media.TransportControllerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.media.TransportMediatorSubject assertThat(
+      android.support.v4.media.TransportMediator target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.media.TransportMediatorSubject, android.support.v4.media.TransportMediator> type = com.pkware.truth.android.support.v4.media.TransportMediatorSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.print.PrintHelperSubject assertThat(
+      android.support.v4.print.PrintHelper target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.print.PrintHelperSubject, android.support.v4.print.PrintHelper> type = com.pkware.truth.android.support.v4.print.PrintHelperSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.util.AtomicFileSubject assertThat(
+      android.support.v4.util.AtomicFile target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.util.AtomicFileSubject, android.support.v4.util.AtomicFile> type = com.pkware.truth.android.support.v4.util.AtomicFileSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static <E> com.pkware.truth.android.support.v4.util.CircularArraySubject<E> assertThat(
+      android.support.v4.util.CircularArray<E> target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.util.CircularArraySubject<E>, android.support.v4.util.CircularArray<E>> type = com.pkware.truth.android.support.v4.util.CircularArraySubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.util.LongSparseArraySubject assertThat(
+      android.support.v4.util.LongSparseArray target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.util.LongSparseArraySubject, android.support.v4.util.LongSparseArray> type = com.pkware.truth.android.support.v4.util.LongSparseArraySubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static <K, V> com.pkware.truth.android.support.v4.util.LruCacheSubject<K, V> assertThat(
+      android.support.v4.util.LruCache<K, V> target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.util.LruCacheSubject<K, V>, android.support.v4.util.LruCache<K, V>> type = com.pkware.truth.android.support.v4.util.LruCacheSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static <E> com.pkware.truth.android.support.v4.util.SparseArrayCompatSubject<E> assertThat(
+      android.support.v4.util.SparseArrayCompat<E> target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.util.SparseArrayCompatSubject<E>, android.support.v4.util.SparseArrayCompat<E>> type = com.pkware.truth.android.support.v4.util.SparseArrayCompatSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.view.PagerAdapterSubject assertThat(
+      android.support.v4.view.PagerAdapter target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.view.PagerAdapterSubject, android.support.v4.view.PagerAdapter> type = com.pkware.truth.android.support.v4.view.PagerAdapterSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.view.ViewPagerSubject assertThat(
+      android.support.v4.view.ViewPager target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.view.ViewPagerSubject, android.support.v4.view.ViewPager> type = com.pkware.truth.android.support.v4.view.ViewPagerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.widget.CursorAdapterSubject assertThat(
+      android.support.v4.widget.CursorAdapter target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.widget.CursorAdapterSubject, android.support.v4.widget.CursorAdapter> type = com.pkware.truth.android.support.v4.widget.CursorAdapterSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.widget.SimpleCursorAdapterSubject assertThat(
+      android.support.v4.widget.SimpleCursorAdapter target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.widget.SimpleCursorAdapterSubject, android.support.v4.widget.SimpleCursorAdapter> type = com.pkware.truth.android.support.v4.widget.SimpleCursorAdapterSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.widget.SlidingPaneLayoutSubject assertThat(
+      android.support.v4.widget.SlidingPaneLayout target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.widget.SlidingPaneLayoutSubject, android.support.v4.widget.SlidingPaneLayout> type = com.pkware.truth.android.support.v4.widget.SlidingPaneLayoutSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.support.v4.widget.SwipeRefreshLayoutSubject assertThat(
+      android.support.v4.widget.SwipeRefreshLayout target) {
+    SubjectFactory<com.pkware.truth.android.support.v4.widget.SwipeRefreshLayoutSubject, android.support.v4.widget.SwipeRefreshLayout> type = com.pkware.truth.android.support.v4.widget.SwipeRefreshLayoutSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  private Assertions() {
+    throw new AssertionError("No instances.");
+  }
+}

--- a/truth-android/src/main/java/com/pkware/truth/android/Assertions.java
+++ b/truth-android/src/main/java/com/pkware/truth/android/Assertions.java
@@ -1,0 +1,1360 @@
+// Copyright 2016 PKWARE, Inc.
+//
+// This class is generated. Do not modify directly!
+package com.pkware.truth.android;
+
+import com.google.common.truth.SubjectFactory;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+/** Assertions for testing Android classes. */
+@SuppressWarnings("deprecation")
+public final class Assertions {
+  public static com.pkware.truth.android.accessibilityservice.AccessibilityServiceInfoSubject assertThat(
+      android.accessibilityservice.AccessibilityServiceInfo target) {
+    SubjectFactory<com.pkware.truth.android.accessibilityservice.AccessibilityServiceInfoSubject, android.accessibilityservice.AccessibilityServiceInfo> type = com.pkware.truth.android.accessibilityservice.AccessibilityServiceInfoSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.accounts.AccountSubject assertThat(
+      android.accounts.Account target) {
+    SubjectFactory<com.pkware.truth.android.accounts.AccountSubject, android.accounts.Account> type = com.pkware.truth.android.accounts.AccountSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.animation.AnimatorSetSubject assertThat(
+      android.animation.AnimatorSet target) {
+    SubjectFactory<com.pkware.truth.android.animation.AnimatorSetSubject, android.animation.AnimatorSet> type = com.pkware.truth.android.animation.AnimatorSetSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.animation.AnimatorSubject assertThat(
+      android.animation.Animator target) {
+    SubjectFactory<com.pkware.truth.android.animation.AnimatorSubject, android.animation.Animator> type = com.pkware.truth.android.animation.AnimatorSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.animation.KeyframeSubject assertThat(
+      android.animation.Keyframe target) {
+    SubjectFactory<com.pkware.truth.android.animation.KeyframeSubject, android.animation.Keyframe> type = com.pkware.truth.android.animation.KeyframeSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.animation.ObjectAnimatorSubject assertThat(
+      android.animation.ObjectAnimator target) {
+    SubjectFactory<com.pkware.truth.android.animation.ObjectAnimatorSubject, android.animation.ObjectAnimator> type = com.pkware.truth.android.animation.ObjectAnimatorSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.animation.PropertyValuesHolderSubject assertThat(
+      android.animation.PropertyValuesHolder target) {
+    SubjectFactory<com.pkware.truth.android.animation.PropertyValuesHolderSubject, android.animation.PropertyValuesHolder> type = com.pkware.truth.android.animation.PropertyValuesHolderSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.animation.ValueAnimatorSubject assertThat(
+      android.animation.ValueAnimator target) {
+    SubjectFactory<com.pkware.truth.android.animation.ValueAnimatorSubject, android.animation.ValueAnimator> type = com.pkware.truth.android.animation.ValueAnimatorSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.ActionBarSubject assertThat(
+      android.app.ActionBar target) {
+    SubjectFactory<com.pkware.truth.android.app.ActionBarSubject, android.app.ActionBar> type = com.pkware.truth.android.app.ActionBarSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.ActivitySubject assertThat(
+      android.app.Activity target) {
+    SubjectFactory<com.pkware.truth.android.app.ActivitySubject, android.app.Activity> type = com.pkware.truth.android.app.ActivitySubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.DialogFragmentSubject assertThat(
+      android.app.DialogFragment target) {
+    SubjectFactory<com.pkware.truth.android.app.DialogFragmentSubject, android.app.DialogFragment> type = com.pkware.truth.android.app.DialogFragmentSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.DialogSubject assertThat(
+      android.app.Dialog target) {
+    SubjectFactory<com.pkware.truth.android.app.DialogSubject, android.app.Dialog> type = com.pkware.truth.android.app.DialogSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.ExpandableListActivitySubject assertThat(
+      android.app.ExpandableListActivity target) {
+    SubjectFactory<com.pkware.truth.android.app.ExpandableListActivitySubject, android.app.ExpandableListActivity> type = com.pkware.truth.android.app.ExpandableListActivitySubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.FragmentManagerSubject assertThat(
+      android.app.FragmentManager target) {
+    SubjectFactory<com.pkware.truth.android.app.FragmentManagerSubject, android.app.FragmentManager> type = com.pkware.truth.android.app.FragmentManagerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.FragmentSubject assertThat(
+      android.app.Fragment target) {
+    SubjectFactory<com.pkware.truth.android.app.FragmentSubject, android.app.Fragment> type = com.pkware.truth.android.app.FragmentSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.FragmentTransactionSubject assertThat(
+      android.app.FragmentTransaction target) {
+    SubjectFactory<com.pkware.truth.android.app.FragmentTransactionSubject, android.app.FragmentTransaction> type = com.pkware.truth.android.app.FragmentTransactionSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.InstrumentationActivityMonitorSubject assertThat(
+      android.app.Instrumentation.ActivityMonitor target) {
+    SubjectFactory<com.pkware.truth.android.app.InstrumentationActivityMonitorSubject, android.app.Instrumentation.ActivityMonitor> type = com.pkware.truth.android.app.InstrumentationActivityMonitorSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.InstrumentationActivityResultSubject assertThat(
+      android.app.Instrumentation.ActivityResult target) {
+    SubjectFactory<com.pkware.truth.android.app.InstrumentationActivityResultSubject, android.app.Instrumentation.ActivityResult> type = com.pkware.truth.android.app.InstrumentationActivityResultSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.KeyguardManagerSubject assertThat(
+      android.app.KeyguardManager target) {
+    SubjectFactory<com.pkware.truth.android.app.KeyguardManagerSubject, android.app.KeyguardManager> type = com.pkware.truth.android.app.KeyguardManagerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.ListActivitySubject assertThat(
+      android.app.ListActivity target) {
+    SubjectFactory<com.pkware.truth.android.app.ListActivitySubject, android.app.ListActivity> type = com.pkware.truth.android.app.ListActivitySubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.ListFragmentSubject assertThat(
+      android.app.ListFragment target) {
+    SubjectFactory<com.pkware.truth.android.app.ListFragmentSubject, android.app.ListFragment> type = com.pkware.truth.android.app.ListFragmentSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.LoaderManagerSubject assertThat(
+      android.app.LoaderManager target) {
+    SubjectFactory<com.pkware.truth.android.app.LoaderManagerSubject, android.app.LoaderManager> type = com.pkware.truth.android.app.LoaderManagerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.LocalActivityManagerSubject assertThat(
+      android.app.LocalActivityManager target) {
+    SubjectFactory<com.pkware.truth.android.app.LocalActivityManagerSubject, android.app.LocalActivityManager> type = com.pkware.truth.android.app.LocalActivityManagerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.NotificationSubject assertThat(
+      android.app.Notification target) {
+    SubjectFactory<com.pkware.truth.android.app.NotificationSubject, android.app.Notification> type = com.pkware.truth.android.app.NotificationSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.PendingIntentSubject assertThat(
+      android.app.PendingIntent target) {
+    SubjectFactory<com.pkware.truth.android.app.PendingIntentSubject, android.app.PendingIntent> type = com.pkware.truth.android.app.PendingIntentSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.ProgressDialogSubject assertThat(
+      android.app.ProgressDialog target) {
+    SubjectFactory<com.pkware.truth.android.app.ProgressDialogSubject, android.app.ProgressDialog> type = com.pkware.truth.android.app.ProgressDialogSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.ServiceSubject assertThat(
+      android.app.Service target) {
+    SubjectFactory<com.pkware.truth.android.app.ServiceSubject, android.app.Service> type = com.pkware.truth.android.app.ServiceSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.TaskStackBuilderSubject assertThat(
+      android.app.TaskStackBuilder target) {
+    SubjectFactory<com.pkware.truth.android.app.TaskStackBuilderSubject, android.app.TaskStackBuilder> type = com.pkware.truth.android.app.TaskStackBuilderSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.app.UiModeManagerSubject assertThat(
+      android.app.UiModeManager target) {
+    SubjectFactory<com.pkware.truth.android.app.UiModeManagerSubject, android.app.UiModeManager> type = com.pkware.truth.android.app.UiModeManagerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.bluetooth.BluetoothClassSubject assertThat(
+      android.bluetooth.BluetoothClass target) {
+    SubjectFactory<com.pkware.truth.android.bluetooth.BluetoothClassSubject, android.bluetooth.BluetoothClass> type = com.pkware.truth.android.bluetooth.BluetoothClassSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.bluetooth.BluetoothDeviceSubject assertThat(
+      android.bluetooth.BluetoothDevice target) {
+    SubjectFactory<com.pkware.truth.android.bluetooth.BluetoothDeviceSubject, android.bluetooth.BluetoothDevice> type = com.pkware.truth.android.bluetooth.BluetoothDeviceSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.bluetooth.BluetoothGattCharacteristicSubject assertThat(
+      android.bluetooth.BluetoothGattCharacteristic target) {
+    SubjectFactory<com.pkware.truth.android.bluetooth.BluetoothGattCharacteristicSubject, android.bluetooth.BluetoothGattCharacteristic> type = com.pkware.truth.android.bluetooth.BluetoothGattCharacteristicSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.bluetooth.BluetoothGattDescriptorSubject assertThat(
+      android.bluetooth.BluetoothGattDescriptor target) {
+    SubjectFactory<com.pkware.truth.android.bluetooth.BluetoothGattDescriptorSubject, android.bluetooth.BluetoothGattDescriptor> type = com.pkware.truth.android.bluetooth.BluetoothGattDescriptorSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.bluetooth.BluetoothGattServiceSubject assertThat(
+      android.bluetooth.BluetoothGattService target) {
+    SubjectFactory<com.pkware.truth.android.bluetooth.BluetoothGattServiceSubject, android.bluetooth.BluetoothGattService> type = com.pkware.truth.android.bluetooth.BluetoothGattServiceSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.content.AsyncTaskLoaderSubject assertThat(
+      android.content.AsyncTaskLoader target) {
+    SubjectFactory<com.pkware.truth.android.content.AsyncTaskLoaderSubject, android.content.AsyncTaskLoader> type = com.pkware.truth.android.content.AsyncTaskLoaderSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.content.ContentValuesSubject assertThat(
+      android.content.ContentValues target) {
+    SubjectFactory<com.pkware.truth.android.content.ContentValuesSubject, android.content.ContentValues> type = com.pkware.truth.android.content.ContentValuesSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.content.CursorLoaderSubject assertThat(
+      android.content.CursorLoader target) {
+    SubjectFactory<com.pkware.truth.android.content.CursorLoaderSubject, android.content.CursorLoader> type = com.pkware.truth.android.content.CursorLoaderSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.content.IntentSubject assertThat(
+      android.content.Intent target) {
+    SubjectFactory<com.pkware.truth.android.content.IntentSubject, android.content.Intent> type = com.pkware.truth.android.content.IntentSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.content.LoaderSubject assertThat(
+      android.content.Loader target) {
+    SubjectFactory<com.pkware.truth.android.content.LoaderSubject, android.content.Loader> type = com.pkware.truth.android.content.LoaderSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.content.SharedPreferencesSubject assertThat(
+      android.content.SharedPreferences target) {
+    SubjectFactory<com.pkware.truth.android.content.SharedPreferencesSubject, android.content.SharedPreferences> type = com.pkware.truth.android.content.SharedPreferencesSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.content.res.ConfigurationSubject assertThat(
+      android.content.res.Configuration target) {
+    SubjectFactory<com.pkware.truth.android.content.res.ConfigurationSubject, android.content.res.Configuration> type = com.pkware.truth.android.content.res.ConfigurationSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.database.AbstractCursor_Subject assertThat(
+      android.database.AbstractCursor target) {
+    SubjectFactory<com.pkware.truth.android.database.AbstractCursor_Subject, android.database.AbstractCursor> type = com.pkware.truth.android.database.AbstractCursor_Subject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.database.CursorSubject assertThat(
+      android.database.Cursor target) {
+    SubjectFactory<com.pkware.truth.android.database.CursorSubject, android.database.Cursor> type = com.pkware.truth.android.database.CursorSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.database.CursorWindowSubject assertThat(
+      android.database.CursorWindow target) {
+    SubjectFactory<com.pkware.truth.android.database.CursorWindowSubject, android.database.CursorWindow> type = com.pkware.truth.android.database.CursorWindowSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.database.sqlite.SqliteDatabaseSubject assertThat(
+      android.database.sqlite.SQLiteDatabase target) {
+    SubjectFactory<com.pkware.truth.android.database.sqlite.SqliteDatabaseSubject, android.database.sqlite.SQLiteDatabase> type = com.pkware.truth.android.database.sqlite.SqliteDatabaseSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.gesture.GestureLibrarySubject assertThat(
+      android.gesture.GestureLibrary target) {
+    SubjectFactory<com.pkware.truth.android.gesture.GestureLibrarySubject, android.gesture.GestureLibrary> type = com.pkware.truth.android.gesture.GestureLibrarySubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.gesture.GestureOverlayViewSubject assertThat(
+      android.gesture.GestureOverlayView target) {
+    SubjectFactory<com.pkware.truth.android.gesture.GestureOverlayViewSubject, android.gesture.GestureOverlayView> type = com.pkware.truth.android.gesture.GestureOverlayViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.gesture.GesturePointSubject assertThat(
+      android.gesture.GesturePoint target) {
+    SubjectFactory<com.pkware.truth.android.gesture.GesturePointSubject, android.gesture.GesturePoint> type = com.pkware.truth.android.gesture.GesturePointSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.gesture.GestureStoreSubject assertThat(
+      android.gesture.GestureStore target) {
+    SubjectFactory<com.pkware.truth.android.gesture.GestureStoreSubject, android.gesture.GestureStore> type = com.pkware.truth.android.gesture.GestureStoreSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.gesture.GestureStrokeSubject assertThat(
+      android.gesture.GestureStroke target) {
+    SubjectFactory<com.pkware.truth.android.gesture.GestureStrokeSubject, android.gesture.GestureStroke> type = com.pkware.truth.android.gesture.GestureStrokeSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.gesture.GestureSubject assertThat(
+      android.gesture.Gesture target) {
+    SubjectFactory<com.pkware.truth.android.gesture.GestureSubject, android.gesture.Gesture> type = com.pkware.truth.android.gesture.GestureSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.gesture.OrientedBoundingBoxSubject assertThat(
+      android.gesture.OrientedBoundingBox target) {
+    SubjectFactory<com.pkware.truth.android.gesture.OrientedBoundingBoxSubject, android.gesture.OrientedBoundingBox> type = com.pkware.truth.android.gesture.OrientedBoundingBoxSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.gesture.PredictionSubject assertThat(
+      android.gesture.Prediction target) {
+    SubjectFactory<com.pkware.truth.android.gesture.PredictionSubject, android.gesture.Prediction> type = com.pkware.truth.android.gesture.PredictionSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.BitmapRegionDecoderSubject assertThat(
+      android.graphics.BitmapRegionDecoder target) {
+    SubjectFactory<com.pkware.truth.android.graphics.BitmapRegionDecoderSubject, android.graphics.BitmapRegionDecoder> type = com.pkware.truth.android.graphics.BitmapRegionDecoderSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.BitmapSubject assertThat(
+      android.graphics.Bitmap target) {
+    SubjectFactory<com.pkware.truth.android.graphics.BitmapSubject, android.graphics.Bitmap> type = com.pkware.truth.android.graphics.BitmapSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.CameraSubject assertThat(
+      android.graphics.Camera target) {
+    SubjectFactory<com.pkware.truth.android.graphics.CameraSubject, android.graphics.Camera> type = com.pkware.truth.android.graphics.CameraSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.CanvasSubject assertThat(
+      android.graphics.Canvas target) {
+    SubjectFactory<com.pkware.truth.android.graphics.CanvasSubject, android.graphics.Canvas> type = com.pkware.truth.android.graphics.CanvasSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.InterpolatorSubject assertThat(
+      android.graphics.Interpolator target) {
+    SubjectFactory<com.pkware.truth.android.graphics.InterpolatorSubject, android.graphics.Interpolator> type = com.pkware.truth.android.graphics.InterpolatorSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.MatrixSubject assertThat(
+      android.graphics.Matrix target) {
+    SubjectFactory<com.pkware.truth.android.graphics.MatrixSubject, android.graphics.Matrix> type = com.pkware.truth.android.graphics.MatrixSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.MovieSubject assertThat(
+      android.graphics.Movie target) {
+    SubjectFactory<com.pkware.truth.android.graphics.MovieSubject, android.graphics.Movie> type = com.pkware.truth.android.graphics.MovieSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.NinePatchSubject assertThat(
+      android.graphics.NinePatch target) {
+    SubjectFactory<com.pkware.truth.android.graphics.NinePatchSubject, android.graphics.NinePatch> type = com.pkware.truth.android.graphics.NinePatchSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.PaintSubject assertThat(
+      android.graphics.Paint target) {
+    SubjectFactory<com.pkware.truth.android.graphics.PaintSubject, android.graphics.Paint> type = com.pkware.truth.android.graphics.PaintSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.PathMeasureSubject assertThat(
+      android.graphics.PathMeasure target) {
+    SubjectFactory<com.pkware.truth.android.graphics.PathMeasureSubject, android.graphics.PathMeasure> type = com.pkware.truth.android.graphics.PathMeasureSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.PathSubject assertThat(
+      android.graphics.Path target) {
+    SubjectFactory<com.pkware.truth.android.graphics.PathSubject, android.graphics.Path> type = com.pkware.truth.android.graphics.PathSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.PictureSubject assertThat(
+      android.graphics.Picture target) {
+    SubjectFactory<com.pkware.truth.android.graphics.PictureSubject, android.graphics.Picture> type = com.pkware.truth.android.graphics.PictureSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.PointFSubject assertThat(
+      android.graphics.PointF target) {
+    SubjectFactory<com.pkware.truth.android.graphics.PointFSubject, android.graphics.PointF> type = com.pkware.truth.android.graphics.PointFSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.PointSubject assertThat(
+      android.graphics.Point target) {
+    SubjectFactory<com.pkware.truth.android.graphics.PointSubject, android.graphics.Point> type = com.pkware.truth.android.graphics.PointSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.RectFSubject assertThat(
+      android.graphics.RectF target) {
+    SubjectFactory<com.pkware.truth.android.graphics.RectFSubject, android.graphics.RectF> type = com.pkware.truth.android.graphics.RectFSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.RectSubject assertThat(
+      android.graphics.Rect target) {
+    SubjectFactory<com.pkware.truth.android.graphics.RectSubject, android.graphics.Rect> type = com.pkware.truth.android.graphics.RectSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.RegionSubject assertThat(
+      android.graphics.Region target) {
+    SubjectFactory<com.pkware.truth.android.graphics.RegionSubject, android.graphics.Region> type = com.pkware.truth.android.graphics.RegionSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.TypefaceSubject assertThat(
+      android.graphics.Typeface target) {
+    SubjectFactory<com.pkware.truth.android.graphics.TypefaceSubject, android.graphics.Typeface> type = com.pkware.truth.android.graphics.TypefaceSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.YuvImageSubject assertThat(
+      android.graphics.YuvImage target) {
+    SubjectFactory<com.pkware.truth.android.graphics.YuvImageSubject, android.graphics.YuvImage> type = com.pkware.truth.android.graphics.YuvImageSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.drawable.AnimationDrawableSubject assertThat(
+      android.graphics.drawable.AnimationDrawable target) {
+    SubjectFactory<com.pkware.truth.android.graphics.drawable.AnimationDrawableSubject, android.graphics.drawable.AnimationDrawable> type = com.pkware.truth.android.graphics.drawable.AnimationDrawableSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.drawable.BitmapDrawableSubject assertThat(
+      android.graphics.drawable.BitmapDrawable target) {
+    SubjectFactory<com.pkware.truth.android.graphics.drawable.BitmapDrawableSubject, android.graphics.drawable.BitmapDrawable> type = com.pkware.truth.android.graphics.drawable.BitmapDrawableSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.drawable.ColorDrawableSubject assertThat(
+      android.graphics.drawable.ColorDrawable target) {
+    SubjectFactory<com.pkware.truth.android.graphics.drawable.ColorDrawableSubject, android.graphics.drawable.ColorDrawable> type = com.pkware.truth.android.graphics.drawable.ColorDrawableSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.drawable.DrawableSubject assertThat(
+      android.graphics.drawable.Drawable target) {
+    SubjectFactory<com.pkware.truth.android.graphics.drawable.DrawableSubject, android.graphics.drawable.Drawable> type = com.pkware.truth.android.graphics.drawable.DrawableSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.drawable.GradientDrawableSubject assertThat(
+      android.graphics.drawable.GradientDrawable target) {
+    SubjectFactory<com.pkware.truth.android.graphics.drawable.GradientDrawableSubject, android.graphics.drawable.GradientDrawable> type = com.pkware.truth.android.graphics.drawable.GradientDrawableSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.drawable.LayerDrawableSubject assertThat(
+      android.graphics.drawable.LayerDrawable target) {
+    SubjectFactory<com.pkware.truth.android.graphics.drawable.LayerDrawableSubject, android.graphics.drawable.LayerDrawable> type = com.pkware.truth.android.graphics.drawable.LayerDrawableSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.drawable.TransitionDrawableSubject assertThat(
+      android.graphics.drawable.TransitionDrawable target) {
+    SubjectFactory<com.pkware.truth.android.graphics.drawable.TransitionDrawableSubject, android.graphics.drawable.TransitionDrawable> type = com.pkware.truth.android.graphics.drawable.TransitionDrawableSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.graphics.drawable.shapes.ShapeSubject assertThat(
+      android.graphics.drawable.shapes.Shape target) {
+    SubjectFactory<com.pkware.truth.android.graphics.drawable.shapes.ShapeSubject, android.graphics.drawable.shapes.Shape> type = com.pkware.truth.android.graphics.drawable.shapes.ShapeSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.hardware.SensorEventSubject assertThat(
+      android.hardware.SensorEvent target) {
+    SubjectFactory<com.pkware.truth.android.hardware.SensorEventSubject, android.hardware.SensorEvent> type = com.pkware.truth.android.hardware.SensorEventSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.hardware.SensorSubject assertThat(
+      android.hardware.Sensor target) {
+    SubjectFactory<com.pkware.truth.android.hardware.SensorSubject, android.hardware.Sensor> type = com.pkware.truth.android.hardware.SensorSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.hardware.usb.UsbAccessorySubject assertThat(
+      android.hardware.usb.UsbAccessory target) {
+    SubjectFactory<com.pkware.truth.android.hardware.usb.UsbAccessorySubject, android.hardware.usb.UsbAccessory> type = com.pkware.truth.android.hardware.usb.UsbAccessorySubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.hardware.usb.UsbDeviceConnectionSubject assertThat(
+      android.hardware.usb.UsbDeviceConnection target) {
+    SubjectFactory<com.pkware.truth.android.hardware.usb.UsbDeviceConnectionSubject, android.hardware.usb.UsbDeviceConnection> type = com.pkware.truth.android.hardware.usb.UsbDeviceConnectionSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.hardware.usb.UsbDeviceSubject assertThat(
+      android.hardware.usb.UsbDevice target) {
+    SubjectFactory<com.pkware.truth.android.hardware.usb.UsbDeviceSubject, android.hardware.usb.UsbDevice> type = com.pkware.truth.android.hardware.usb.UsbDeviceSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.hardware.usb.UsbEndpointSubject assertThat(
+      android.hardware.usb.UsbEndpoint target) {
+    SubjectFactory<com.pkware.truth.android.hardware.usb.UsbEndpointSubject, android.hardware.usb.UsbEndpoint> type = com.pkware.truth.android.hardware.usb.UsbEndpointSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.hardware.usb.UsbInterfaceSubject assertThat(
+      android.hardware.usb.UsbInterface target) {
+    SubjectFactory<com.pkware.truth.android.hardware.usb.UsbInterfaceSubject, android.hardware.usb.UsbInterface> type = com.pkware.truth.android.hardware.usb.UsbInterfaceSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.hardware.usb.UsbRequestSubject assertThat(
+      android.hardware.usb.UsbRequest target) {
+    SubjectFactory<com.pkware.truth.android.hardware.usb.UsbRequestSubject, android.hardware.usb.UsbRequest> type = com.pkware.truth.android.hardware.usb.UsbRequestSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.inputmethodservice.ExtractEditTextSubject assertThat(
+      android.inputmethodservice.ExtractEditText target) {
+    SubjectFactory<com.pkware.truth.android.inputmethodservice.ExtractEditTextSubject, android.inputmethodservice.ExtractEditText> type = com.pkware.truth.android.inputmethodservice.ExtractEditTextSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.location.AddressSubject assertThat(
+      android.location.Address target) {
+    SubjectFactory<com.pkware.truth.android.location.AddressSubject, android.location.Address> type = com.pkware.truth.android.location.AddressSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.location.CriteriaSubject assertThat(
+      android.location.Criteria target) {
+    SubjectFactory<com.pkware.truth.android.location.CriteriaSubject, android.location.Criteria> type = com.pkware.truth.android.location.CriteriaSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.location.GpsSatelliteSubject assertThat(
+      android.location.GpsSatellite target) {
+    SubjectFactory<com.pkware.truth.android.location.GpsSatelliteSubject, android.location.GpsSatellite> type = com.pkware.truth.android.location.GpsSatelliteSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.location.GpsStatusSubject assertThat(
+      android.location.GpsStatus target) {
+    SubjectFactory<com.pkware.truth.android.location.GpsStatusSubject, android.location.GpsStatus> type = com.pkware.truth.android.location.GpsStatusSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.location.LocationProviderSubject assertThat(
+      android.location.LocationProvider target) {
+    SubjectFactory<com.pkware.truth.android.location.LocationProviderSubject, android.location.LocationProvider> type = com.pkware.truth.android.location.LocationProviderSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.location.LocationSubject assertThat(
+      android.location.Location target) {
+    SubjectFactory<com.pkware.truth.android.location.LocationSubject, android.location.Location> type = com.pkware.truth.android.location.LocationSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.net.UriSubject assertThat(
+      android.net.Uri target) {
+    SubjectFactory<com.pkware.truth.android.net.UriSubject, android.net.Uri> type = com.pkware.truth.android.net.UriSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.os.AsyncTaskSubject assertThat(
+      android.os.AsyncTask target) {
+    SubjectFactory<com.pkware.truth.android.os.AsyncTaskSubject, android.os.AsyncTask> type = com.pkware.truth.android.os.AsyncTaskSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.os.BundleSubject assertThat(
+      android.os.Bundle target) {
+    SubjectFactory<com.pkware.truth.android.os.BundleSubject, android.os.Bundle> type = com.pkware.truth.android.os.BundleSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.os.PowerManagerSubject assertThat(
+      android.os.PowerManager target) {
+    SubjectFactory<com.pkware.truth.android.os.PowerManagerSubject, android.os.PowerManager> type = com.pkware.truth.android.os.PowerManagerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.os.VibratorSubject assertThat(
+      android.os.Vibrator target) {
+    SubjectFactory<com.pkware.truth.android.os.VibratorSubject, android.os.Vibrator> type = com.pkware.truth.android.os.VibratorSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.preferences.CheckBoxPreferenceSubject assertThat(
+      android.preference.CheckBoxPreference target) {
+    SubjectFactory<com.pkware.truth.android.preferences.CheckBoxPreferenceSubject, android.preference.CheckBoxPreference> type = com.pkware.truth.android.preferences.CheckBoxPreferenceSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.preferences.DialogPreferenceSubject assertThat(
+      android.preference.DialogPreference target) {
+    SubjectFactory<com.pkware.truth.android.preferences.DialogPreferenceSubject, android.preference.DialogPreference> type = com.pkware.truth.android.preferences.DialogPreferenceSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.preferences.EditTextPreferencesSubject assertThat(
+      android.preference.EditTextPreference target) {
+    SubjectFactory<com.pkware.truth.android.preferences.EditTextPreferencesSubject, android.preference.EditTextPreference> type = com.pkware.truth.android.preferences.EditTextPreferencesSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.preferences.ListPreferenceSubject assertThat(
+      android.preference.ListPreference target) {
+    SubjectFactory<com.pkware.truth.android.preferences.ListPreferenceSubject, android.preference.ListPreference> type = com.pkware.truth.android.preferences.ListPreferenceSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.preferences.MultiSelectListPreferenceSubject assertThat(
+      android.preference.MultiSelectListPreference target) {
+    SubjectFactory<com.pkware.truth.android.preferences.MultiSelectListPreferenceSubject, android.preference.MultiSelectListPreference> type = com.pkware.truth.android.preferences.MultiSelectListPreferenceSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.preferences.PreferenceActivitySubject assertThat(
+      android.preference.PreferenceActivity target) {
+    SubjectFactory<com.pkware.truth.android.preferences.PreferenceActivitySubject, android.preference.PreferenceActivity> type = com.pkware.truth.android.preferences.PreferenceActivitySubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.preferences.PreferenceGroupSubject assertThat(
+      android.preference.PreferenceGroup target) {
+    SubjectFactory<com.pkware.truth.android.preferences.PreferenceGroupSubject, android.preference.PreferenceGroup> type = com.pkware.truth.android.preferences.PreferenceGroupSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.preferences.PreferenceScreenSubject assertThat(
+      android.preference.PreferenceScreen target) {
+    SubjectFactory<com.pkware.truth.android.preferences.PreferenceScreenSubject, android.preference.PreferenceScreen> type = com.pkware.truth.android.preferences.PreferenceScreenSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.preferences.PreferenceSubject assertThat(
+      android.preference.Preference target) {
+    SubjectFactory<com.pkware.truth.android.preferences.PreferenceSubject, android.preference.Preference> type = com.pkware.truth.android.preferences.PreferenceSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.preferences.RingtonePreferenceSubject assertThat(
+      android.preference.RingtonePreference target) {
+    SubjectFactory<com.pkware.truth.android.preferences.RingtonePreferenceSubject, android.preference.RingtonePreference> type = com.pkware.truth.android.preferences.RingtonePreferenceSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.preferences.SwitchPreferenceSubject assertThat(
+      android.preference.SwitchPreference target) {
+    SubjectFactory<com.pkware.truth.android.preferences.SwitchPreferenceSubject, android.preference.SwitchPreference> type = com.pkware.truth.android.preferences.SwitchPreferenceSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.preferences.TwoStatePreferenceSubject assertThat(
+      android.preference.TwoStatePreference target) {
+    SubjectFactory<com.pkware.truth.android.preferences.TwoStatePreferenceSubject, android.preference.TwoStatePreference> type = com.pkware.truth.android.preferences.TwoStatePreferenceSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.CellIdentityCdmaSubject assertThat(
+      android.telephony.CellIdentityCdma target) {
+    SubjectFactory<com.pkware.truth.android.telephony.CellIdentityCdmaSubject, android.telephony.CellIdentityCdma> type = com.pkware.truth.android.telephony.CellIdentityCdmaSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.CellIdentityGsmSubject assertThat(
+      android.telephony.CellIdentityGsm target) {
+    SubjectFactory<com.pkware.truth.android.telephony.CellIdentityGsmSubject, android.telephony.CellIdentityGsm> type = com.pkware.truth.android.telephony.CellIdentityGsmSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.CellIdentityLteSubject assertThat(
+      android.telephony.CellIdentityLte target) {
+    SubjectFactory<com.pkware.truth.android.telephony.CellIdentityLteSubject, android.telephony.CellIdentityLte> type = com.pkware.truth.android.telephony.CellIdentityLteSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.CellIdentityWcdmaSubject assertThat(
+      android.telephony.CellIdentityWcdma target) {
+    SubjectFactory<com.pkware.truth.android.telephony.CellIdentityWcdmaSubject, android.telephony.CellIdentityWcdma> type = com.pkware.truth.android.telephony.CellIdentityWcdmaSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.CellInfoCdmaSubject assertThat(
+      android.telephony.CellInfoCdma target) {
+    SubjectFactory<com.pkware.truth.android.telephony.CellInfoCdmaSubject, android.telephony.CellInfoCdma> type = com.pkware.truth.android.telephony.CellInfoCdmaSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.CellInfoGsmSubject assertThat(
+      android.telephony.CellInfoGsm target) {
+    SubjectFactory<com.pkware.truth.android.telephony.CellInfoGsmSubject, android.telephony.CellInfoGsm> type = com.pkware.truth.android.telephony.CellInfoGsmSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.CellInfoLteSubject assertThat(
+      android.telephony.CellInfoLte target) {
+    SubjectFactory<com.pkware.truth.android.telephony.CellInfoLteSubject, android.telephony.CellInfoLte> type = com.pkware.truth.android.telephony.CellInfoLteSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.CellInfoWcdmaSubject assertThat(
+      android.telephony.CellInfoWcdma target) {
+    SubjectFactory<com.pkware.truth.android.telephony.CellInfoWcdmaSubject, android.telephony.CellInfoWcdma> type = com.pkware.truth.android.telephony.CellInfoWcdmaSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.CellSignalStrengthCdmaSubject assertThat(
+      android.telephony.CellSignalStrengthCdma target) {
+    SubjectFactory<com.pkware.truth.android.telephony.CellSignalStrengthCdmaSubject, android.telephony.CellSignalStrengthCdma> type = com.pkware.truth.android.telephony.CellSignalStrengthCdmaSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.CellSignalStrengthGsmSubject assertThat(
+      android.telephony.CellSignalStrengthGsm target) {
+    SubjectFactory<com.pkware.truth.android.telephony.CellSignalStrengthGsmSubject, android.telephony.CellSignalStrengthGsm> type = com.pkware.truth.android.telephony.CellSignalStrengthGsmSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.CellSignalStrengthLteSubject assertThat(
+      android.telephony.CellSignalStrengthLte target) {
+    SubjectFactory<com.pkware.truth.android.telephony.CellSignalStrengthLteSubject, android.telephony.CellSignalStrengthLte> type = com.pkware.truth.android.telephony.CellSignalStrengthLteSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.CellSignalStrengthWcdmaSubject assertThat(
+      android.telephony.CellSignalStrengthWcdma target) {
+    SubjectFactory<com.pkware.truth.android.telephony.CellSignalStrengthWcdmaSubject, android.telephony.CellSignalStrengthWcdma> type = com.pkware.truth.android.telephony.CellSignalStrengthWcdmaSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.NeighboringCellInfoSubject assertThat(
+      android.telephony.NeighboringCellInfo target) {
+    SubjectFactory<com.pkware.truth.android.telephony.NeighboringCellInfoSubject, android.telephony.NeighboringCellInfo> type = com.pkware.truth.android.telephony.NeighboringCellInfoSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.ServiceStateSubject assertThat(
+      android.telephony.ServiceState target) {
+    SubjectFactory<com.pkware.truth.android.telephony.ServiceStateSubject, android.telephony.ServiceState> type = com.pkware.truth.android.telephony.ServiceStateSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.SignalStrengthSubject assertThat(
+      android.telephony.SignalStrength target) {
+    SubjectFactory<com.pkware.truth.android.telephony.SignalStrengthSubject, android.telephony.SignalStrength> type = com.pkware.truth.android.telephony.SignalStrengthSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.SmsMessageSubject assertThat(
+      android.telephony.SmsMessage target) {
+    SubjectFactory<com.pkware.truth.android.telephony.SmsMessageSubject, android.telephony.SmsMessage> type = com.pkware.truth.android.telephony.SmsMessageSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.TelephonyManagerSubject assertThat(
+      android.telephony.TelephonyManager target) {
+    SubjectFactory<com.pkware.truth.android.telephony.TelephonyManagerSubject, android.telephony.TelephonyManager> type = com.pkware.truth.android.telephony.TelephonyManagerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.cdma.CdmaCellLocationSubject assertThat(
+      android.telephony.cdma.CdmaCellLocation target) {
+    SubjectFactory<com.pkware.truth.android.telephony.cdma.CdmaCellLocationSubject, android.telephony.cdma.CdmaCellLocation> type = com.pkware.truth.android.telephony.cdma.CdmaCellLocationSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.telephony.gsm.GsmCellLocationSubject assertThat(
+      android.telephony.gsm.GsmCellLocation target) {
+    SubjectFactory<com.pkware.truth.android.telephony.gsm.GsmCellLocationSubject, android.telephony.gsm.GsmCellLocation> type = com.pkware.truth.android.telephony.gsm.GsmCellLocationSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.text.BidiFormatterSubject assertThat(
+      android.text.BidiFormatter target) {
+    SubjectFactory<com.pkware.truth.android.text.BidiFormatterSubject, android.text.BidiFormatter> type = com.pkware.truth.android.text.BidiFormatterSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static <K, V> com.pkware.truth.android.util.ArrayMapSubject<K, V> assertThat(
+      android.util.ArrayMap<K, V> target) {
+    SubjectFactory<com.pkware.truth.android.util.ArrayMapSubject<K, V>, android.util.ArrayMap<K, V>> type = com.pkware.truth.android.util.ArrayMapSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.util.AtomicFileSubject assertThat(
+      android.util.AtomicFile target) {
+    SubjectFactory<com.pkware.truth.android.util.AtomicFileSubject, android.util.AtomicFile> type = com.pkware.truth.android.util.AtomicFileSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.util.AttributeSetSubject assertThat(
+      android.util.AttributeSet target) {
+    SubjectFactory<com.pkware.truth.android.util.AttributeSetSubject, android.util.AttributeSet> type = com.pkware.truth.android.util.AttributeSetSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.util.DisplayMetricsSubject assertThat(
+      android.util.DisplayMetrics target) {
+    SubjectFactory<com.pkware.truth.android.util.DisplayMetricsSubject, android.util.DisplayMetrics> type = com.pkware.truth.android.util.DisplayMetricsSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.util.LongSparseArraySubject assertThat(
+      android.util.LongSparseArray target) {
+    SubjectFactory<com.pkware.truth.android.util.LongSparseArraySubject, android.util.LongSparseArray> type = com.pkware.truth.android.util.LongSparseArraySubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static <K, V> com.pkware.truth.android.util.LruCacheSubject<K, V> assertThat(
+      android.util.LruCache<K, V> target) {
+    SubjectFactory<com.pkware.truth.android.util.LruCacheSubject<K, V>, android.util.LruCache<K, V>> type = com.pkware.truth.android.util.LruCacheSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static <F, S> com.pkware.truth.android.util.PairSubject<F, S> assertThat(
+      android.util.Pair<F, S> target) {
+    SubjectFactory<com.pkware.truth.android.util.PairSubject<F, S>, android.util.Pair<F, S>> type = com.pkware.truth.android.util.PairSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static <T, V> com.pkware.truth.android.util.PropertySubject<T, V> assertThat(
+      android.util.Property<T, V> target) {
+    SubjectFactory<com.pkware.truth.android.util.PropertySubject<T, V>, android.util.Property<T, V>> type = com.pkware.truth.android.util.PropertySubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static <E> com.pkware.truth.android.util.SparseArraySubject<E> assertThat(
+      android.util.SparseArray<E> target) {
+    SubjectFactory<com.pkware.truth.android.util.SparseArraySubject<E>, android.util.SparseArray<E>> type = com.pkware.truth.android.util.SparseArraySubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.util.SparseBooleanArraySubject assertThat(
+      android.util.SparseBooleanArray target) {
+    SubjectFactory<com.pkware.truth.android.util.SparseBooleanArraySubject, android.util.SparseBooleanArray> type = com.pkware.truth.android.util.SparseBooleanArraySubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.util.SparseIntArraySubject assertThat(
+      android.util.SparseIntArray target) {
+    SubjectFactory<com.pkware.truth.android.util.SparseIntArraySubject, android.util.SparseIntArray> type = com.pkware.truth.android.util.SparseIntArraySubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.util.SparseLongArraySubject assertThat(
+      android.util.SparseLongArray target) {
+    SubjectFactory<com.pkware.truth.android.util.SparseLongArraySubject, android.util.SparseLongArray> type = com.pkware.truth.android.util.SparseLongArraySubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.ActionModeSubject assertThat(
+      android.view.ActionMode target) {
+    SubjectFactory<com.pkware.truth.android.view.ActionModeSubject, android.view.ActionMode> type = com.pkware.truth.android.view.ActionModeSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.ActionProviderSubject assertThat(
+      android.view.ActionProvider target) {
+    SubjectFactory<com.pkware.truth.android.view.ActionProviderSubject, android.view.ActionProvider> type = com.pkware.truth.android.view.ActionProviderSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.DisplaySubject assertThat(
+      android.view.Display target) {
+    SubjectFactory<com.pkware.truth.android.view.DisplaySubject, android.view.Display> type = com.pkware.truth.android.view.DisplaySubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.DragEventSubject assertThat(
+      android.view.DragEvent target) {
+    SubjectFactory<com.pkware.truth.android.view.DragEventSubject, android.view.DragEvent> type = com.pkware.truth.android.view.DragEventSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.KeyCharacterMapSubject assertThat(
+      android.view.KeyCharacterMap target) {
+    SubjectFactory<com.pkware.truth.android.view.KeyCharacterMapSubject, android.view.KeyCharacterMap> type = com.pkware.truth.android.view.KeyCharacterMapSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.KeyEventSubject assertThat(
+      android.view.KeyEvent target) {
+    SubjectFactory<com.pkware.truth.android.view.KeyEventSubject, android.view.KeyEvent> type = com.pkware.truth.android.view.KeyEventSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.MenuItemSubject assertThat(
+      android.view.MenuItem target) {
+    SubjectFactory<com.pkware.truth.android.view.MenuItemSubject, android.view.MenuItem> type = com.pkware.truth.android.view.MenuItemSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.MenuSubject assertThat(
+      android.view.Menu target) {
+    SubjectFactory<com.pkware.truth.android.view.MenuSubject, android.view.Menu> type = com.pkware.truth.android.view.MenuSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.OrientationEventListenerSubject assertThat(
+      android.view.OrientationEventListener target) {
+    SubjectFactory<com.pkware.truth.android.view.OrientationEventListenerSubject, android.view.OrientationEventListener> type = com.pkware.truth.android.view.OrientationEventListenerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.ScaleGestureDetectorSubject assertThat(
+      android.view.ScaleGestureDetector target) {
+    SubjectFactory<com.pkware.truth.android.view.ScaleGestureDetectorSubject, android.view.ScaleGestureDetector> type = com.pkware.truth.android.view.ScaleGestureDetectorSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.SurfaceSubject assertThat(
+      android.view.Surface target) {
+    SubjectFactory<com.pkware.truth.android.view.SurfaceSubject, android.view.Surface> type = com.pkware.truth.android.view.SurfaceSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.TextureViewSubject assertThat(
+      android.view.TextureView target) {
+    SubjectFactory<com.pkware.truth.android.view.TextureViewSubject, android.view.TextureView> type = com.pkware.truth.android.view.TextureViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.VelocityTrackerSubject assertThat(
+      android.view.VelocityTracker target) {
+    SubjectFactory<com.pkware.truth.android.view.VelocityTrackerSubject, android.view.VelocityTracker> type = com.pkware.truth.android.view.VelocityTrackerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.ViewConfigurationSubject assertThat(
+      android.view.ViewConfiguration target) {
+    SubjectFactory<com.pkware.truth.android.view.ViewConfigurationSubject, android.view.ViewConfiguration> type = com.pkware.truth.android.view.ViewConfigurationSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.ViewGroupLayoutParamsSubject assertThat(
+      android.view.ViewGroup.LayoutParams target) {
+    SubjectFactory<com.pkware.truth.android.view.ViewGroupLayoutParamsSubject, android.view.ViewGroup.LayoutParams> type = com.pkware.truth.android.view.ViewGroupLayoutParamsSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.ViewGroupMarginLayoutParamsSubject assertThat(
+      android.view.ViewGroup.MarginLayoutParams target) {
+    SubjectFactory<com.pkware.truth.android.view.ViewGroupMarginLayoutParamsSubject, android.view.ViewGroup.MarginLayoutParams> type = com.pkware.truth.android.view.ViewGroupMarginLayoutParamsSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.ViewGroupSubject assertThat(
+      android.view.ViewGroup target) {
+    SubjectFactory<com.pkware.truth.android.view.ViewGroupSubject, android.view.ViewGroup> type = com.pkware.truth.android.view.ViewGroupSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.ViewPropertyAnimatorSubject assertThat(
+      android.view.ViewPropertyAnimator target) {
+    SubjectFactory<com.pkware.truth.android.view.ViewPropertyAnimatorSubject, android.view.ViewPropertyAnimator> type = com.pkware.truth.android.view.ViewPropertyAnimatorSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.ViewStubSubject assertThat(
+      android.view.ViewStub target) {
+    SubjectFactory<com.pkware.truth.android.view.ViewStubSubject, android.view.ViewStub> type = com.pkware.truth.android.view.ViewStubSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.ViewSubject assertThat(
+      android.view.View target) {
+    SubjectFactory<com.pkware.truth.android.view.ViewSubject, android.view.View> type = com.pkware.truth.android.view.ViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.ViewTreeObserverSubject assertThat(
+      android.view.ViewTreeObserver target) {
+    SubjectFactory<com.pkware.truth.android.view.ViewTreeObserverSubject, android.view.ViewTreeObserver> type = com.pkware.truth.android.view.ViewTreeObserverSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.WindowSubject assertThat(
+      android.view.Window target) {
+    SubjectFactory<com.pkware.truth.android.view.WindowSubject, android.view.Window> type = com.pkware.truth.android.view.WindowSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.accessbility.AccessibilityEventSubject assertThat(
+      android.view.accessibility.AccessibilityEvent target) {
+    SubjectFactory<com.pkware.truth.android.view.accessbility.AccessibilityEventSubject, android.view.accessibility.AccessibilityEvent> type = com.pkware.truth.android.view.accessbility.AccessibilityEventSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.accessbility.AccessibilityManagerSubject assertThat(
+      android.view.accessibility.AccessibilityManager target) {
+    SubjectFactory<com.pkware.truth.android.view.accessbility.AccessibilityManagerSubject, android.view.accessibility.AccessibilityManager> type = com.pkware.truth.android.view.accessbility.AccessibilityManagerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.accessbility.AccessibilityNodeInfoSubject assertThat(
+      android.view.accessibility.AccessibilityNodeInfo target) {
+    SubjectFactory<com.pkware.truth.android.view.accessbility.AccessibilityNodeInfoSubject, android.view.accessibility.AccessibilityNodeInfo> type = com.pkware.truth.android.view.accessbility.AccessibilityNodeInfoSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.accessbility.AccessibilityRecordSubject assertThat(
+      android.view.accessibility.AccessibilityRecord target) {
+    SubjectFactory<com.pkware.truth.android.view.accessbility.AccessibilityRecordSubject, android.view.accessibility.AccessibilityRecord> type = com.pkware.truth.android.view.accessbility.AccessibilityRecordSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.animation.AnimationSetSubject assertThat(
+      android.view.animation.AnimationSet target) {
+    SubjectFactory<com.pkware.truth.android.view.animation.AnimationSetSubject, android.view.animation.AnimationSet> type = com.pkware.truth.android.view.animation.AnimationSetSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.animation.AnimationSubject assertThat(
+      android.view.animation.Animation target) {
+    SubjectFactory<com.pkware.truth.android.view.animation.AnimationSubject, android.view.animation.Animation> type = com.pkware.truth.android.view.animation.AnimationSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.animation.GridLayoutAnimationControllerSubject assertThat(
+      android.view.animation.GridLayoutAnimationController target) {
+    SubjectFactory<com.pkware.truth.android.view.animation.GridLayoutAnimationControllerSubject, android.view.animation.GridLayoutAnimationController> type = com.pkware.truth.android.view.animation.GridLayoutAnimationControllerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.animation.LayoutAnimationControllerSubject assertThat(
+      android.view.animation.LayoutAnimationController target) {
+    SubjectFactory<com.pkware.truth.android.view.animation.LayoutAnimationControllerSubject, android.view.animation.LayoutAnimationController> type = com.pkware.truth.android.view.animation.LayoutAnimationControllerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.view.animation.TransformationSubject assertThat(
+      android.view.animation.Transformation target) {
+    SubjectFactory<com.pkware.truth.android.view.animation.TransformationSubject, android.view.animation.Transformation> type = com.pkware.truth.android.view.animation.TransformationSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.webkit.WebViewSubject assertThat(
+      android.webkit.WebView target) {
+    SubjectFactory<com.pkware.truth.android.webkit.WebViewSubject, android.webkit.WebView> type = com.pkware.truth.android.webkit.WebViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.AdapterSubject assertThat(
+      android.widget.Adapter target) {
+    SubjectFactory<com.pkware.truth.android.widget.AdapterSubject, android.widget.Adapter> type = com.pkware.truth.android.widget.AdapterSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.AdapterViewSubject assertThat(
+      android.widget.AdapterView target) {
+    SubjectFactory<com.pkware.truth.android.widget.AdapterViewSubject, android.widget.AdapterView> type = com.pkware.truth.android.widget.AdapterViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.ArrayAdapterSubject assertThat(
+      android.widget.ArrayAdapter target) {
+    SubjectFactory<com.pkware.truth.android.widget.ArrayAdapterSubject, android.widget.ArrayAdapter> type = com.pkware.truth.android.widget.ArrayAdapterSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.AutoCompleteTextViewSubject assertThat(
+      android.widget.AutoCompleteTextView target) {
+    SubjectFactory<com.pkware.truth.android.widget.AutoCompleteTextViewSubject, android.widget.AutoCompleteTextView> type = com.pkware.truth.android.widget.AutoCompleteTextViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.CalendarViewSubject assertThat(
+      android.widget.CalendarView target) {
+    SubjectFactory<com.pkware.truth.android.widget.CalendarViewSubject, android.widget.CalendarView> type = com.pkware.truth.android.widget.CalendarViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.CheckedTextViewSubject assertThat(
+      android.widget.CheckedTextView target) {
+    SubjectFactory<com.pkware.truth.android.widget.CheckedTextViewSubject, android.widget.CheckedTextView> type = com.pkware.truth.android.widget.CheckedTextViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.ChronometerSubject assertThat(
+      android.widget.Chronometer target) {
+    SubjectFactory<com.pkware.truth.android.widget.ChronometerSubject, android.widget.Chronometer> type = com.pkware.truth.android.widget.ChronometerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.CompoundButtonSubject assertThat(
+      android.widget.CompoundButton target) {
+    SubjectFactory<com.pkware.truth.android.widget.CompoundButtonSubject, android.widget.CompoundButton> type = com.pkware.truth.android.widget.CompoundButtonSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.CursorAdapterSubject assertThat(
+      android.widget.CursorAdapter target) {
+    SubjectFactory<com.pkware.truth.android.widget.CursorAdapterSubject, android.widget.CursorAdapter> type = com.pkware.truth.android.widget.CursorAdapterSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.DatePickerSubject assertThat(
+      android.widget.DatePicker target) {
+    SubjectFactory<com.pkware.truth.android.widget.DatePickerSubject, android.widget.DatePicker> type = com.pkware.truth.android.widget.DatePickerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.ExpandableListViewSubject assertThat(
+      android.widget.ExpandableListView target) {
+    SubjectFactory<com.pkware.truth.android.widget.ExpandableListViewSubject, android.widget.ExpandableListView> type = com.pkware.truth.android.widget.ExpandableListViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.FrameLayoutSubject assertThat(
+      android.widget.FrameLayout target) {
+    SubjectFactory<com.pkware.truth.android.widget.FrameLayoutSubject, android.widget.FrameLayout> type = com.pkware.truth.android.widget.FrameLayoutSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.GridLayoutSubject assertThat(
+      android.widget.GridLayout target) {
+    SubjectFactory<com.pkware.truth.android.widget.GridLayoutSubject, android.widget.GridLayout> type = com.pkware.truth.android.widget.GridLayoutSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.GridViewSubject assertThat(
+      android.widget.GridView target) {
+    SubjectFactory<com.pkware.truth.android.widget.GridViewSubject, android.widget.GridView> type = com.pkware.truth.android.widget.GridViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.HeaderViewListAdapterSubject assertThat(
+      android.widget.HeaderViewListAdapter target) {
+    SubjectFactory<com.pkware.truth.android.widget.HeaderViewListAdapterSubject, android.widget.HeaderViewListAdapter> type = com.pkware.truth.android.widget.HeaderViewListAdapterSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.HorizontalScrollViewSubject assertThat(
+      android.widget.HorizontalScrollView target) {
+    SubjectFactory<com.pkware.truth.android.widget.HorizontalScrollViewSubject, android.widget.HorizontalScrollView> type = com.pkware.truth.android.widget.HorizontalScrollViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.ImageViewSubject assertThat(
+      android.widget.ImageView target) {
+    SubjectFactory<com.pkware.truth.android.widget.ImageViewSubject, android.widget.ImageView> type = com.pkware.truth.android.widget.ImageViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.LinearLayoutSubject assertThat(
+      android.widget.LinearLayout target) {
+    SubjectFactory<com.pkware.truth.android.widget.LinearLayoutSubject, android.widget.LinearLayout> type = com.pkware.truth.android.widget.LinearLayoutSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.ListAdapterSubject assertThat(
+      android.widget.ListAdapter target) {
+    SubjectFactory<com.pkware.truth.android.widget.ListAdapterSubject, android.widget.ListAdapter> type = com.pkware.truth.android.widget.ListAdapterSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.ListPopupWindowSubject assertThat(
+      android.widget.ListPopupWindow target) {
+    SubjectFactory<com.pkware.truth.android.widget.ListPopupWindowSubject, android.widget.ListPopupWindow> type = com.pkware.truth.android.widget.ListPopupWindowSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.ListViewSubject assertThat(
+      android.widget.ListView target) {
+    SubjectFactory<com.pkware.truth.android.widget.ListViewSubject, android.widget.ListView> type = com.pkware.truth.android.widget.ListViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.MediaControllerSubject assertThat(
+      android.widget.MediaController target) {
+    SubjectFactory<com.pkware.truth.android.widget.MediaControllerSubject, android.widget.MediaController> type = com.pkware.truth.android.widget.MediaControllerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.NumberPickerSubject assertThat(
+      android.widget.NumberPicker target) {
+    SubjectFactory<com.pkware.truth.android.widget.NumberPickerSubject, android.widget.NumberPicker> type = com.pkware.truth.android.widget.NumberPickerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.PopupWindowSubject assertThat(
+      android.widget.PopupWindow target) {
+    SubjectFactory<com.pkware.truth.android.widget.PopupWindowSubject, android.widget.PopupWindow> type = com.pkware.truth.android.widget.PopupWindowSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.ProgressBarSubject assertThat(
+      android.widget.ProgressBar target) {
+    SubjectFactory<com.pkware.truth.android.widget.ProgressBarSubject, android.widget.ProgressBar> type = com.pkware.truth.android.widget.ProgressBarSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.RadioGroupSubject assertThat(
+      android.widget.RadioGroup target) {
+    SubjectFactory<com.pkware.truth.android.widget.RadioGroupSubject, android.widget.RadioGroup> type = com.pkware.truth.android.widget.RadioGroupSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.RatingBarSubject assertThat(
+      android.widget.RatingBar target) {
+    SubjectFactory<com.pkware.truth.android.widget.RatingBarSubject, android.widget.RatingBar> type = com.pkware.truth.android.widget.RatingBarSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.RelativeLayoutSubject assertThat(
+      android.widget.RelativeLayout target) {
+    SubjectFactory<com.pkware.truth.android.widget.RelativeLayoutSubject, android.widget.RelativeLayout> type = com.pkware.truth.android.widget.RelativeLayoutSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.ScrollViewSubject assertThat(
+      android.widget.ScrollView target) {
+    SubjectFactory<com.pkware.truth.android.widget.ScrollViewSubject, android.widget.ScrollView> type = com.pkware.truth.android.widget.ScrollViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.SearchViewSubject assertThat(
+      android.widget.SearchView target) {
+    SubjectFactory<com.pkware.truth.android.widget.SearchViewSubject, android.widget.SearchView> type = com.pkware.truth.android.widget.SearchViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.SimpleAdapterSubject assertThat(
+      android.widget.SimpleAdapter target) {
+    SubjectFactory<com.pkware.truth.android.widget.SimpleAdapterSubject, android.widget.SimpleAdapter> type = com.pkware.truth.android.widget.SimpleAdapterSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.SimpleCursorAdapterSubject assertThat(
+      android.widget.SimpleCursorAdapter target) {
+    SubjectFactory<com.pkware.truth.android.widget.SimpleCursorAdapterSubject, android.widget.SimpleCursorAdapter> type = com.pkware.truth.android.widget.SimpleCursorAdapterSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.SlidingDrawerSubject assertThat(
+      android.widget.SlidingDrawer target) {
+    SubjectFactory<com.pkware.truth.android.widget.SlidingDrawerSubject, android.widget.SlidingDrawer> type = com.pkware.truth.android.widget.SlidingDrawerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.SpinnerSubject assertThat(
+      android.widget.Spinner target) {
+    SubjectFactory<com.pkware.truth.android.widget.SpinnerSubject, android.widget.Spinner> type = com.pkware.truth.android.widget.SpinnerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.SwitchSubject assertThat(
+      android.widget.Switch target) {
+    SubjectFactory<com.pkware.truth.android.widget.SwitchSubject, android.widget.Switch> type = com.pkware.truth.android.widget.SwitchSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.TabHostSubject assertThat(
+      android.widget.TabHost target) {
+    SubjectFactory<com.pkware.truth.android.widget.TabHostSubject, android.widget.TabHost> type = com.pkware.truth.android.widget.TabHostSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.TabWidgetSubject assertThat(
+      android.widget.TabWidget target) {
+    SubjectFactory<com.pkware.truth.android.widget.TabWidgetSubject, android.widget.TabWidget> type = com.pkware.truth.android.widget.TabWidgetSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.TableLayoutSubject assertThat(
+      android.widget.TableLayout target) {
+    SubjectFactory<com.pkware.truth.android.widget.TableLayoutSubject, android.widget.TableLayout> type = com.pkware.truth.android.widget.TableLayoutSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.TableRowSubject assertThat(
+      android.widget.TableRow target) {
+    SubjectFactory<com.pkware.truth.android.widget.TableRowSubject, android.widget.TableRow> type = com.pkware.truth.android.widget.TableRowSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.TextViewSubject assertThat(
+      android.widget.TextView target) {
+    SubjectFactory<com.pkware.truth.android.widget.TextViewSubject, android.widget.TextView> type = com.pkware.truth.android.widget.TextViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.TimePickerSubject assertThat(
+      android.widget.TimePicker target) {
+    SubjectFactory<com.pkware.truth.android.widget.TimePickerSubject, android.widget.TimePicker> type = com.pkware.truth.android.widget.TimePickerSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.ToastSubject assertThat(
+      android.widget.Toast target) {
+    SubjectFactory<com.pkware.truth.android.widget.ToastSubject, android.widget.Toast> type = com.pkware.truth.android.widget.ToastSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.ToggleButtonSubject assertThat(
+      android.widget.ToggleButton target) {
+    SubjectFactory<com.pkware.truth.android.widget.ToggleButtonSubject, android.widget.ToggleButton> type = com.pkware.truth.android.widget.ToggleButtonSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.VideoViewSubject assertThat(
+      android.widget.VideoView target) {
+    SubjectFactory<com.pkware.truth.android.widget.VideoViewSubject, android.widget.VideoView> type = com.pkware.truth.android.widget.VideoViewSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.ViewAnimatorSubject assertThat(
+      android.widget.ViewAnimator target) {
+    SubjectFactory<com.pkware.truth.android.widget.ViewAnimatorSubject, android.widget.ViewAnimator> type = com.pkware.truth.android.widget.ViewAnimatorSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.ViewFlipperSubject assertThat(
+      android.widget.ViewFlipper target) {
+    SubjectFactory<com.pkware.truth.android.widget.ViewFlipperSubject, android.widget.ViewFlipper> type = com.pkware.truth.android.widget.ViewFlipperSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.ViewSwitcherSubject assertThat(
+      android.widget.ViewSwitcher target) {
+    SubjectFactory<com.pkware.truth.android.widget.ViewSwitcherSubject, android.widget.ViewSwitcher> type = com.pkware.truth.android.widget.ViewSwitcherSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  public static com.pkware.truth.android.widget.WrapperListAdapterSubject assertThat(
+      android.widget.WrapperListAdapter target) {
+    SubjectFactory<com.pkware.truth.android.widget.WrapperListAdapterSubject, android.widget.WrapperListAdapter> type = com.pkware.truth.android.widget.WrapperListAdapterSubject.type();
+    return assertAbout(type).that(target);
+  }
+
+  private Assertions() {
+    throw new AssertionError("No instances.");
+  }
+}


### PR DESCRIPTION
This provides an easy way to use the assertions and will be all that most developers need. This does produce a limitation though. By generating the code, we need all of the `SubjectFactory`s to be exposed in a predictable way, so providing custom anf human-friendly static factory methods on each Subject is not possible.