### PR TITLE
Migrate to the newer "maven-publish" plugin

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,12 +3,14 @@ Releasing
 
  1. Change the version in `gradle.properties` to a non-SNAPSHOT version.
  1. If the release is not a `rc`, `beta`, or similar, change the version in `website/index.html`.
- 2. Update the `CHANGELOG.md` for the impending release.
- 4. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
- 5. `git tag -a X.Y.X -m "Version X.Y.Z"` (where X.Y.Z is the new version)
- 6. `./gradlew clean uploadArchives`
+ 1. Update the `CHANGELOG.md` for the impending release.
+ 1. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
+ 1. `./gradlew clean publish`
+ 1. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
+ 1. `git tag -a X.Y.X -m "Version X.Y.Z"` (where X.Y.Z is the new version)
  1. If you updated `website/index.html`, run the `deploy_website.sh` script.
- 7. Update the `gradle.properties` to the next SNAPSHOT version.
- 8. `git commit -am "Prepare next development version."`
- 9. `git push && git push --tags`
- 10. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
+ 1. Update the `gradle.properties` to the next SNAPSHOT version.
+ 1. `git commit -am "Prepare next development version."`
+ 1. `git push && git push --tags`
+
+If step 5 or 6 fails, drop the Sonatype repo, fix the problem, commit, and start again at step 5.

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ subprojects {
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.5.3'
+            classpath 'digital.wup:android-maven-publish:3.6.3'
         }
     }
 
@@ -45,18 +46,4 @@ ext {
 
     materialComponents = "com.google.android.material:material:1.0.0"
     playServices = 'com.google.android.gms:play-services:7.5.0'
-}
-
-subprojects {
-    afterEvaluate {
-        android.libraryVariants.all { variant ->
-            def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
-            task.description = "Create jar artifact for ${variant.name}"
-            task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}.jar"
-            artifacts.add('archives', task);
-        }
-    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,8 +6,8 @@ VERSION_NAME=2.1.0-SNAPSHOT
 
 POM_DESCRIPTION=A set of Truth subjects geared toward testing Android.
 
-POM_URL=http://github.com/pkware/truth-android/
-POM_SCM_URL=http://github.com/pkware/truth-android/
+POM_URL=https://github.com/pkware/truth-android/
+POM_SCM_URL=https://github.com/pkware/truth-android/
 POM_SCM_CONNECTION=scm:git:git://github.com/pkware/truth-android.git
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/pkware/truth-android.git
 

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-apply plugin: 'maven'
+apply plugin: 'digital.wup.android-maven-publish'
 apply plugin: 'signing'
 
 def isReleaseBuild() {
@@ -33,78 +33,80 @@ def getRepositoryPassword() {
             : System.getenv("SONATYPE_NEXUS_PASSWORD") ?: ""
 }
 
-afterEvaluate { project ->
-    uploadArchives {
-        repositories {
-            mavenDeployer {
-                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+task androidJavadocs(type: Javadoc) {
+    source = android.sourceSets.main.java.source
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
 
-                pom.groupId = GROUP
-                pom.artifactId = POM_ARTIFACT_ID
-                pom.version = VERSION_NAME
+    if (JavaVersion.current().isJava8Compatible()) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+    }
+    if (JavaVersion.current().isJava9Compatible()) {
+        options.addBooleanOption('html5', true)
+    }
+}
 
-                repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+    classifier = 'javadoc'
+    from androidJavadocs.destinationDir
+}
+
+task androidSourcesJar(type: Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.java.source
+}
+
+publishing {
+    publications {
+        mavenAndroid(MavenPublication) {
+            groupId = GROUP
+            artifactId = POM_ARTIFACT_ID
+            version = VERSION_NAME
+            from components.android
+            artifact androidSourcesJar
+            artifact androidJavadocsJar
+
+            pom {
+                name = POM_NAME
+                packaging = POM_PACKAGING
+                description = POM_DESCRIPTION
+                url = POM_URL
+
+                scm {
+                    url = POM_SCM_URL
+                    connection = POM_SCM_CONNECTION
+                    developerConnection = POM_SCM_DEV_CONNECTION
                 }
-                snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+
+                licenses {
+                    license {
+                        name = POM_LICENCE_NAME
+                        url = POM_LICENCE_URL
+                        distribution = POM_LICENCE_DIST
+                    }
                 }
 
-                pom.project {
-                    name POM_NAME
-                    packaging POM_PACKAGING
-                    description POM_DESCRIPTION
-                    url POM_URL
-
-                    scm {
-                        url POM_SCM_URL
-                        connection POM_SCM_CONNECTION
-                        developerConnection POM_SCM_DEV_CONNECTION
-                    }
-
-                    licenses {
-                        license {
-                            name POM_LICENCE_NAME
-                            url POM_LICENCE_URL
-                            distribution POM_LICENCE_DIST
-                        }
-                    }
-
-                    developers {
-                        developer {
-                            id POM_DEVELOPER_ID
-                            name POM_DEVELOPER_NAME
-                        }
+                developers {
+                    developer {
+                        id = POM_DEVELOPER_ID
+                        name = POM_DEVELOPER_NAME
                     }
                 }
             }
         }
     }
-
-    signing {
-        required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
-        sign configurations.archives
+    repositories {
+        maven {
+            url = isReleaseBuild()
+                    ? "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                    : "https://oss.sonatype.org/content/repositories/snapshots/"
+            credentials {
+                username = getRepositoryUsername()
+                password = getRepositoryPassword()
+            }
+        }
     }
+}
 
-    task androidJavadocs(type: Javadoc) {
-        source = android.sourceSets.main.java.srcDirs
-        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-
-        options.addStringOption('Xdoclint:none', '-quiet')
-    }
-
-    task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-        classifier = 'javadoc'
-        from androidJavadocs.destinationDir
-    }
-
-    task androidSourcesJar(type: Jar) {
-        classifier = 'sources'
-        from android.sourceSets.main.java.sourceFiles
-    }
-
-    artifacts {
-        archives androidSourcesJar
-        archives androidJavadocsJar
-    }
+signing {
+    sign publishing.publications.mavenAndroid
 }


### PR DESCRIPTION
The "maven" gradle plugin has been replaced by a newer "maven-publish" plugin. Unfortunately, the "maven-publish" plugin itself doesn't integrate super smoothly with Android projects. Instead, we use the "android-maven-publish" plugin, which handles the hard part of coordinating artifacts.